### PR TITLE
Autoload biblio-init-hook

### DIFF
--- a/biblio-gbooks.el
+++ b/biblio-gbooks.el
@@ -92,6 +92,7 @@ COMMAND, ARG, MORE: See `biblio-backends'."
   (interactive)
   (biblio-lookup #'biblio-gbooks-backend query))
 
+;;;###autoload
 (add-hook 'biblio-init-hook #'biblio-gbooks-backend)
 
 (provide 'biblio-gbooks)


### PR DESCRIPTION
The `biblio-gbooks` package doesn't quite follow the recommendations from the Biblio README.

The `biblio-init-hook` needs to be autoloaded. See the docstring of the `biblio-backends` variable.

Then it can be run using the general purpose `biblio-lookup` command, as an alternative to the specific `biblio-gbooks-lookup` command.

This will also make loading the package easier. In my case, I'd like to configure the package with `use-package` and defered loading. Currently I need to do this:

```
(use-package biblio
  :defer t
  :ensure t)

(use-package biblio-gbooks
  :defer t
  ;; TODO: this hook should be autoloaded by the package itself.
  :hook (biblio-init . biblio-gbooks-backend)
  :ensure t)
``` 

I'd like to remove that `:hook` line.
